### PR TITLE
Fix typerror

### DIFF
--- a/Plugin/Quote/Api/PaymentMethodManagementPlugin.php
+++ b/Plugin/Quote/Api/PaymentMethodManagementPlugin.php
@@ -52,7 +52,7 @@ class PaymentMethodManagementPlugin
             return $result;
         }
 
-        return array_filter($result, function (PaymentMethodInterface $method) {
+        return array_filter($result, function ($method) {
             return in_array($method->getCode(), static::ALLOWED_METHODS);
         });
     }


### PR DESCRIPTION
- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [X] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
Quote API 

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Fix typecasting error while in checkout causing to show no shipping and/or payment information.

`Uncaught TypeError: Argument 1 passed to Mollie\\Subscriptions\\Plugin\\Quote\\Api\\PaymentMethodManagementPlugin::Mollie\\Subscriptions\\Plugin\\Quote\\Api\\{closure}() must implement interface Magento\\Quote\\Api\\Data\\PaymentMethodInterface, instance of Magento\\Payment\\Model\\Method\\Adapter\\Interceptor given.`