### PR TITLE
Bugfix: Move the duplicate subscriptions check

### DIFF
--- a/Observer/CheckoutCartProductAddBefore/PreventDuplicateSubscriptions.php
+++ b/Observer/CheckoutCartProductAddBefore/PreventDuplicateSubscriptions.php
@@ -39,7 +39,8 @@ class PreventDuplicateSubscriptions implements ObserverInterface
             return;
         }
 
-        if ($this->customerAlreadyHasSubscriptionToProduct->execute($this->session->getCustomer(), $product)) {
+        $customer = $this->session->getCustomer();
+        if ($this->customerAlreadyHasSubscriptionToProduct->execute($customer->getDataModel(), $product)) {
             throw new LocalizedException(__('You already have a subscription to this product.'));
         }
     }

--- a/Service/Cart/CustomerAlreadyHasSubscriptionToProduct.php
+++ b/Service/Cart/CustomerAlreadyHasSubscriptionToProduct.php
@@ -4,7 +4,7 @@ namespace Mollie\Subscriptions\Service\Cart;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
-use Magento\Customer\Model\Customer;
+use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\Exception\NotFoundException;
 use Mollie\Subscriptions\Api\SubscriptionToProductRepositoryInterface;
 
@@ -28,7 +28,7 @@ class CustomerAlreadyHasSubscriptionToProduct
         $this->customerRepository = $customerRepository;
     }
 
-    public function execute(Customer $customer, ProductInterface $product): bool
+    public function execute(CustomerInterface $customer, ProductInterface $product): bool
     {
         try {
             $customerData = $this->customerRepository->getById($customer->getId());

--- a/Test/Fakes/Service/Cart/CustomerAlreadyHasSubscriptionToProductFake.php
+++ b/Test/Fakes/Service/Cart/CustomerAlreadyHasSubscriptionToProductFake.php
@@ -3,6 +3,7 @@
 namespace Mollie\Subscriptions\Test\Fakes\Service\Cart;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\Customer;
 use Mollie\Subscriptions\Service\Cart\CustomerAlreadyHasSubscriptionToProduct;
 
@@ -33,7 +34,7 @@ class CustomerAlreadyHasSubscriptionToProductFake extends CustomerAlreadyHasSubs
         $this->shouldNotBeCalled = true;
     }
 
-    public function execute(Customer $customer, ProductInterface $product): bool
+    public function execute(CustomerInterface $customer, ProductInterface $product): bool
     {
         if ($this->shouldNotBeCalled) {
             throw new \Exception('This method should not be called');

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -170,4 +170,8 @@
             <argument name="session" xsi:type="object">Magento\Customer\Model\Session\Proxy</argument>
         </arguments>
     </type>
+
+    <type name="Magento\Checkout\Model\Session">
+        <plugin name="mollie_subscriptions_check_for_duplicates_in_cart" type="Mollie\Subscriptions\Plugin\Checkout\Model\PreventDuplicateSubscriptionProductsInCart" />
+    </type>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -21,7 +21,4 @@
         <observer name="mollie_subscription_check_add_to_cart" instance="Mollie\Subscriptions\Observer\CheckoutCartProductAddBefore\PreventAddingSubscriptionProductsToCartWhenNoSubscriptionIsSelected" />
         <observer name="mollie_subscription_prevent_duplicate_subscription" instance="Mollie\Subscriptions\Observer\CheckoutCartProductAddBefore\PreventDuplicateSubscriptions" />
     </event>
-    <event name="customer_login">
-        <observer name="mollie_subscription_prevent_duplicate_subscription_products_in_cart" instance="Mollie\Subscriptions\Observer\CustomerLogin\PreventDuplicateSubscriptionProductsInCart" />
-    </event>
 </config>

--- a/view/frontend/templates/product/view/subscription-options.phtml
+++ b/view/frontend/templates/product/view/subscription-options.phtml
@@ -31,7 +31,9 @@
             class="action primary tocart product-addtocart-button select-subscription"
             value="<?= $escaper->escapeHtmlAttr($option->getIdentifier()); ?>"
             title="<?= $escaper->escapeHtmlAttr($option->getTitle()) ?>"
-        <?= $escaper->escapeHtml($option->getTitle()); ?>
+            >
+            <?= $escaper->escapeHtml($option->getTitle()); ?>
+        </button>
     <?php endforeach; ?>
 
     <?php /** Instant purchase should be hidden when subscriptions are active */ ?>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...