### PR TITLE
Fix Magento 2.4.5 compatibility issue knockout templates

### DIFF
--- a/view/base/web/template/grid/cursor-based-paging.html
+++ b/view/base/web/template/grid/cursor-based-paging.html
@@ -5,10 +5,10 @@
  */
 -->
 <div class="admin__data-grid-pager-wrap">
-    <scope args="sizes" render=""/>
+    <scope args="sizes" render=""></scope>
 
     <div class="admin__data-grid-pager">
-        <button class="action-previous" type="button" attr="title: $t('Previous Page')" click="prev" disable="!hasPrevious()"/>
-        <button class="action-next" type="button" attr="title: $t('Next Page')" click="next" disable="!hasNext()"/>
+        <button class="action-previous" type="button" attr="title: $t('Previous Page')" click="prev" disable="!hasPrevious()"></button>
+        <button class="action-next" type="button" attr="title: $t('Next Page')" click="next" disable="!hasNext()"></button>
     </div>
 </div>

--- a/view/base/web/template/grid/toolbar.html
+++ b/view/base/web/template/grid/toolbar.html
@@ -6,21 +6,21 @@
 -->
 <div class="admin__data-grid-header" afterRender="$data.setToolbarNode">
     <div class="admin__data-grid-header-row">
-        <div class="admin__data-grid-actions-wrap" each="getRegion('dataGridActions')" render=""/>
-        <each args="getRegion('dataGridFilters')" render=""/>
+        <div class="admin__data-grid-actions-wrap" each="getRegion('dataGridActions')" render=""></div>
+        <each args="getRegion('dataGridFilters')" render=""></each>
     </div>
     <div class="admin__data-grid-header-row row row-gutter">
-        <div class="col-xs-2" if="hasChild('listing_massaction')" ko-scope="requestChild('listing_massaction')" render=""/>
+        <div class="col-xs-2" if="hasChild('listing_massaction')" ko-scope="requestChild('listing_massaction')" render=""></div>
         <div css="
             'col-xs-10': hasChild('listing_massaction'),
             'col-xs-12': !hasChild('listing_massaction')">
             <div class="row" ko-scope="requestChild('listing_paging')">
                 <!-- Disabled: -->
-                <!-- <div class="col-xs-3" render="totalTmpl"/> -->
-                <div class="col-xs-12" render=""/>
+                <!-- <div class="col-xs-3" render="totalTmpl"></div> -->
+                <div class="col-xs-12" render=""></div>
             </div>
         </div>
     </div>
 </div>
 
-<render args="stickyTmpl" if="$data.sticky"/>
+<render args="stickyTmpl" if="$data.sticky"></render>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [x] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

In 2.4.5-p1 The admin grid for the active subscriptions threw a jquery migrate warning when viewed so the data did not load. I have updated the two template files to correct close the elements causing the error.

**Scenario to test this code:**

Open the environment and...