### PR TITLE
Feature: Add option to format the next payment date

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -29,6 +29,7 @@ class Config
     const XML_PATH_EXTENSION_SHIPPING_METHOD = 'mollie_subscriptions/general/shipping_method';
     const XML_PATH_DEBUG = 'mollie_subscriptions/general/debug';
     const XML_PATH_PREPAYMENT_REMINDER_DAYS_BEFORE_REMINDER = 'mollie_subscriptions/prepayment_reminder/days_before_reminder';
+    const XML_PATH_PREPAYMENT_REMINDER_NEXT_PAYMENT_DATE_FORMAT = 'mollie_subscriptions/prepayment_reminder/next_payment_date_format';
     const XML_PATH_PREPAYMENT_REMINDER_ENABLED = 'mollie_subscriptions/prepayment_reminder/enabled';
     const XML_PATH_PREPAYMENT_REMINDER_TEMPLATE = 'mollie_subscriptions/prepayment_reminder/template';
     const XML_PATH_PREPAYMENT_REMINDER_SEND_BCC_TO = 'mollie_subscriptions/prepayment_reminder/send_bcc_to';
@@ -241,6 +242,11 @@ class Config
     public function daysBeforePrepaymentReminder($storeId = null, $scope = ScopeInterface::SCOPE_STORE): ?string
     {
         return $this->getStoreValue(static::XML_PATH_PREPAYMENT_REMINDER_DAYS_BEFORE_REMINDER, $storeId, $scope);
+    }
+
+    public function nextPaymentDateFormat($storeId = null, $scope = ScopeInterface::SCOPE_STORE): string
+    {
+        return $this->getStoreValue(static::XML_PATH_PREPAYMENT_REMINDER_NEXT_PAYMENT_DATE_FORMAT, $storeId, $scope);
     }
 
     /**

--- a/etc/adminhtml/system/prepayment_reminder.xml
+++ b/etc/adminhtml/system/prepayment_reminder.xml
@@ -41,7 +41,17 @@
                 <field id="enabled">1</field>
             </depends>
         </field>
-        <field id="cron_expr" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0"
+        <field id="next_payment_date_format" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
+               showInStore="1">
+            <label>Next payment date format</label>
+            <config_path>mollie_subscriptions/prepayment_reminder/next_payment_date_format</config_path>
+            <comment><![CDATA[How to format the date in the next payment date reminder emails. Must be in a format that is accepted by <a href="https://www.php.net/manual/en/function.date.php" target="_blank">PHP date format</a>]]></comment>
+            <validate>required-entry</validate>
+            <depends>
+                <field id="enabled">1</field>
+            </depends>
+        </field>
+        <field id="cron_expr" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0"
                showInStore="0">
             <label>Cron time</label>
             <config_path>mollie_subscriptions/prepayment_reminder/cron_expr</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -24,6 +24,7 @@
                 <enabled>0</enabled>
                 <template>mollie_subscriptions_pre_payment_reminder_template</template>
                 <days_before_reminder>3</days_before_reminder>
+                <next_payment_date_format>d-m-Y</next_payment_date_format>
                 <cron_expr>0 1 * * *</cron_expr>
             </prepayment_reminder>
             <emails>

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -75,7 +75,7 @@ Type,Type
 "We confirm that you canceled the subscription with ID %subscription_id.","We bevestigen dat u het abonnement met ID %subscription_id heeft geannuleerd."
 "New subscription","Nieuw abonnement"
 "The customer %customerName has started a new subscription with the description %description and ID %subscription_id.","De klant %customerName heeft een nieuw abonnement gestart met de beschrijving %description en ID %subscription_id."
-"Your new subscription","Uw nieuw abonnement"
+"Your new subscription","Uw nieuwe abonnement"
 "Good news! We confirm your subscription to %product_name. The next order will be sent on its way to you on %nextPaymentDate.","Goed nieuws! We bevestigen uw abonnement op %product_name. De volgende bestelling wordt op %nextPaymentDate naar u verzonden."
 "Upcoming subscription renewal from %store_name","Aankomende abonnementsvernieuwing van %store_name"
 "We are very excited to get your %product_name subscription ready for %nextPaymentDate!","We zijn erg enthousiast om uw abonnement op %product_name klaar te maken voor %nextPaymentDate!"


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...