### PR TITLE
Bugfix: Set correct webhook path

### DIFF
--- a/Service/Mollie/SubscriptionOptions.php
+++ b/Service/Mollie/SubscriptionOptions.php
@@ -191,7 +191,7 @@ class SubscriptionOptions
     {
         $this->options['webhookUrl'] = $this->urlBuilder->getUrl(
             'mollie-subscriptions/api/webhook',
-            ['___store' => $this->storeManager->getStore($this->order->getStoreId())->getCode()]
+            ['___store' => $this->storeManager->getStore($this->order->getStoreId())->getId()]
         );
     }
 

--- a/Setup/Patch/Data/UpdateWebhookPath.php
+++ b/Setup/Patch/Data/UpdateWebhookPath.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Subscriptions\Setup\Patch\Data;
+
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Api\StoreRepositoryInterface;
+use Mollie\Api\Resources\Subscription;
+use Mollie\Api\Resources\SubscriptionCollection;
+use Mollie\Payment\Service\Mollie\MollieApiClient;
+
+class UpdateWebhookPath implements DataPatchInterface
+{
+    /**
+     * @var StoreRepositoryInterface
+     */
+    private $storeRepository;
+    /**
+     * @var MollieApiClient
+     */
+    private $mollieApiClient;
+    /**
+     * @var UrlInterface
+     */
+    private $urlBuilder;
+    /**
+     * @var array
+     */
+    private $storeCodeToId = [];
+
+    public function __construct(
+        StoreRepositoryInterface $storeRepository,
+        UrlInterface $urlBuilder,
+        MollieApiClient $mollieApiClient
+    ) {
+        $this->storeRepository = $storeRepository;
+        $this->urlBuilder = $urlBuilder;
+        $this->mollieApiClient = $mollieApiClient;
+    }
+
+    public function apply()
+    {
+        foreach ($this->storeRepository->getList() as $store) {
+            $this->storeCodeToId[$store->getCode()] = $store->getId();
+        }
+
+        foreach ($this->storeRepository->getList() as $store) {
+            try {
+                $api = $this->mollieApiClient->loadByStore((int)$store->getId());
+            } catch (\Exception $exception) {
+                continue;
+            }
+
+            $subscriptions = $api->subscriptions->page();
+            $this->updateSubscriptions($subscriptions);
+        }
+
+        return $this;
+    }
+
+    private function updateSubscriptions(SubscriptionCollection $subscriptions): void
+    {
+        /** @var Subscription $subscription */
+        foreach ($subscriptions as $subscription) {
+            if (!$subscription->isActive()) {
+                return;
+            }
+
+            $this->updateSubscription($subscription);
+        }
+
+        if ($subscriptions->hasNext()) {
+            $this->updateSubscriptions($subscriptions->next());
+        }
+    }
+
+    public function updateSubscription(Subscription $subscription): void
+    {
+        /** @var string $webhookUrl */
+        $webhookUrl = $subscription->webhookUrl;
+        if (strpos($webhookUrl, 'mollie-subscriptions/api/webhook') === false) {
+            return;
+        }
+
+        // Get either /___store/<match>/ or ___store=<match> from the url
+        preg_match('/\/___store\/([^\/]+)\/|___store=([^&]+)/', $webhookUrl, $matches);
+        $storeCode = $matches[1] ?? $matches[2];
+
+        $id = $this->storeCodeToId[$storeCode];
+
+        $newUrl = $this->urlBuilder->getUrl(
+            'mollie-subscriptions/api/webhook',
+            ['___store' => $id]
+        );
+
+        $subscription->webhookUrl = $newUrl;
+        $subscription->update();
+    }
+
+    public function getAliases()
+    {
+        return [];
+    }
+
+    public static function getDependencies()
+    {
+        return [];
+    }
+}

--- a/Test/Integration/Service/Mollie/SubscriptionOptionsTest.php
+++ b/Test/Integration/Service/Mollie/SubscriptionOptionsTest.php
@@ -209,7 +209,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
         $this->assertInstanceOf(SubscriptionOption::class, $subscription);
         $this->assertArrayHasKey('webhookUrl', $subscription->toArray());
         $this->assertStringContainsString('api/webhook', $subscription->toArray()['webhookUrl']);
-        $this->assertStringContainsString('___store/default', $subscription->toArray()['webhookUrl']);
+        $this->assertStringContainsString('___store/1', $subscription->toArray()['webhookUrl']);
     }
 
     /**


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...