### PR TITLE
Bugfix: Return the onetimepurchase option when relevant

### DIFF
--- a/Service/Mollie/GetSelectedOption.php
+++ b/Service/Mollie/GetSelectedOption.php
@@ -6,6 +6,7 @@ namespace Mollie\Subscriptions\Service\Mollie;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Mollie\Subscriptions\DTO\ProductSubscriptionOption;
+use Mollie\Subscriptions\DTO\ProductSubscriptionOptionFactory;
 
 class GetSelectedOption
 {
@@ -13,15 +14,31 @@ class GetSelectedOption
      * @var ParseSubscriptionOptions
      */
     private $parseSubscriptionOptions;
+    /**
+     * @var ProductSubscriptionOptionFactory
+     */
+    private $productSubscriptionOptionFactory;
 
     public function __construct(
-        ParseSubscriptionOptions $parseSubscriptionOptions
+        ParseSubscriptionOptions $parseSubscriptionOptions,
+        ProductSubscriptionOptionFactory $productSubscriptionOptionFactory
     ) {
         $this->parseSubscriptionOptions = $parseSubscriptionOptions;
+        $this->productSubscriptionOptionFactory = $productSubscriptionOptionFactory;
     }
 
     public function execute(ProductInterface $product, string $optionId): ProductSubscriptionOption
     {
+        if ($optionId == 'onetimepurchase') {
+            return $this->productSubscriptionOptionFactory->create([
+                'identifier' => 'onetimepurchase',
+                'title' => __('One Time Purchase'),
+                'interval_amount' => '',
+                'interval_type' => '',
+                'repetition_type' => 'onetime',
+            ]);
+        }
+
         $options = $this->parseSubscriptionOptions->execute($product);
         foreach ($options as $option) {
             if ($option->getIdentifier() === $optionId) {


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...