### PR TITLE
add a few events & make subscription-options more adjustable

### DIFF
--- a/Controller/Api/Webhook.php
+++ b/Controller/Api/Webhook.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\CsrfAwareActionInterface;
 use Magento\Framework\App\Request\InvalidRequestException;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\NotFoundException;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
@@ -23,6 +24,8 @@ use Mollie\Payment\Service\Mollie\Order\LinkTransactionToOrder;
 use Mollie\Payment\Service\Mollie\ValidateMetadata;
 use Mollie\Payment\Service\Order\OrderCommentHistory;
 use Mollie\Payment\Service\Order\SendOrderEmails;
+use Mollie\Subscriptions\Api\Data\SubscriptionToProductInterface;
+use Mollie\Subscriptions\Api\SubscriptionToProductRepositoryInterface;
 use Mollie\Subscriptions\Config;
 use Mollie\Subscriptions\Service\Email\SendForPayment;
 use Mollie\Subscriptions\Service\Magento\CreateOrderFromSubscription;
@@ -99,6 +102,10 @@ class Webhook extends Action implements CsrfAwareActionInterface
      * @var SendForPayment
      */
     private $sendEmailForPayment;
+    /**
+     * @var SubscriptionToProductRepositoryInterface
+     */
+    private $subscriptionToProductRepository;
 
     public function __construct(
         Context $context,
@@ -114,7 +121,8 @@ class Webhook extends Action implements CsrfAwareActionInterface
         SendAdminNotification $sendAdminNotification,
         CreateOrderFromSubscription $createOrderFromSubscription,
         UpdateNextPaymentDate $updateNextPaymentDate,
-        SendForPayment $sendEmailForPayment
+        SendForPayment $sendEmailForPayment,
+        SubscriptionToProductRepositoryInterface $subscriptionToProductRepository
     ) {
         parent::__construct($context);
 
@@ -131,6 +139,7 @@ class Webhook extends Action implements CsrfAwareActionInterface
         $this->createOrderFromSubscription = $createOrderFromSubscription;
         $this->updateNextPaymentDate = $updateNextPaymentDate;
         $this->sendEmailForPayment = $sendEmailForPayment;
+        $this->subscriptionToProductRepository = $subscriptionToProductRepository;
     }
 
     public function execute()
@@ -168,6 +177,18 @@ class Webhook extends Action implements CsrfAwareActionInterface
             $this->linkTransactionToOrder->execute($molliePayment->id, $order);
 
             $this->mollie->processTransactionForOrder($order, Payments::TRANSACTION_TYPE_SUBSCRIPTION);
+
+            try {
+                $subscriptionToProduct = $this->subscriptionToProductRepository->get($molliePayment->subscriptionId);
+                $this->_eventManager->dispatch('mollie_subscription_renewed', [
+                    'order' => $order,
+                    'model' => $subscriptionToProduct,
+                    'subscription' => $subscription,
+                ]);
+            } catch (NoSuchEntityException $e) {
+                // do nothing
+            }
+
             $this->sendEmailForPayment->execute($subscription, $molliePayment);
 
             return $this->returnOkResponse();

--- a/DTO/SubscriptionOption.php
+++ b/DTO/SubscriptionOption.php
@@ -7,6 +7,8 @@
 namespace Mollie\Subscriptions\DTO;
 
 
+use Magento\Sales\Api\Data\OrderItemInterface;
+
 class SubscriptionOption
 {
     /**
@@ -57,6 +59,10 @@ class SubscriptionOption
      * @var int|null
      */
     private $times;
+    /**
+     * @var OrderItemInterface|null
+     */
+    private $orderItem = null;
 
     public function __construct(
         int $productId,
@@ -87,9 +93,19 @@ class SubscriptionOption
         return $this->productId;
     }
 
+    public function setProductId(int $productId): void
+    {
+        $this->productId = $productId;
+    }
+
     public function getOptionId(): string
     {
         return $this->optionId;
+    }
+
+    public function setOptionId(string $optionId): void
+    {
+        $this->optionId = $optionId;
     }
 
     public function getStoreId(): int
@@ -97,19 +113,104 @@ class SubscriptionOption
         return $this->storeId;
     }
 
+    public function setStoreId(int $storeId): void
+    {
+        $this->storeId = $storeId;
+    }
+
+    public function getAmount(): array
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(array $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    public function getInterval(): string
+    {
+        return $this->interval;
+    }
+
+    public function setInterval(string $interval): void
+    {
+        $this->interval = $interval;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    public function setMetadata(array $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function getWebhookUrl(): string
+    {
+        return $this->webhookUrl;
+    }
+
+    public function setWebhookUrl(string $webhookUrl): void
+    {
+        $this->webhookUrl = $webhookUrl;
+    }
+
+    public function getStartDate(): \DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(\DateTimeImmutable $startDate): void
+    {
+        $this->startDate = $startDate;
+    }
+
+    public function getTimes(): ?int
+    {
+        return $this->times;
+    }
+
+    public function setTimes(?int $times): void
+    {
+        $this->times = $times;
+    }
+
+    public function setOrderItem(OrderItemInterface $orderItem)
+    {
+        $this->orderItem = $orderItem;
+    }
+
+    public function getOrderItem(): ?OrderItemInterface
+    {
+        return $this->orderItem;
+    }
+
     public function toArray(): array
     {
         $output = [
-            'amount' => $this->amount,
-            'interval' => $this->interval,
-            'description' => $this->description,
-            'metadata' => $this->metadata,
-            'webhookUrl' => $this->webhookUrl,
-            'startDate' => $this->startDate->format('Y-m-d'),
+            'amount' => $this->getAmount(),
+            'interval' => $this->getInterval(),
+            'description' => $this->getDescription(),
+            'metadata' => $this->getMetadata(),
+            'webhookUrl' => $this->getWebhookUrl(),
+            'startDate' => $this->getStartDate()->format('Y-m-d'),
         ];
 
-        if ($this->times) {
-            $output['times'] = $this->times;
+        if (!is_null($this->getTimes())) {
+            $output['times'] = $this->getTimes();
         }
 
         return $output;

--- a/Observer/MollieProcessTransactionEnd/CreateSubscriptions.php
+++ b/Observer/MollieProcessTransactionEnd/CreateSubscriptions.php
@@ -124,7 +124,7 @@ class CreateSubscriptions implements ObserverInterface
 
         $subscriptions = $this->subscriptionOptions->forOrder($order);
         foreach ($subscriptions as $subscriptionOptions) {
-            $this->createSubscription($payment->customerId, $subscriptionOptions);
+            $this->createSubscription($payment->customerId, $subscriptionOptions, $order);
         }
 
         $order->getPayment()->setAdditionalInformation('subscription_created', date('Y-m-d'));
@@ -143,7 +143,7 @@ class CreateSubscriptions implements ObserverInterface
         return $this->mollieApi->payments->get($transactionId);
     }
 
-    private function createSubscription(string $customerId, SubscriptionOption $subscriptionOptions)
+    private function createSubscription(string $customerId, SubscriptionOption $subscriptionOptions, OrderInterface $order)
     {
         $this->config->addToLog('request', ['customerId' => $customerId, 'options' => $subscriptionOptions->toArray()]);
         $subscription = $this->mollieApi->subscriptions->createForId($customerId, $subscriptionOptions->toArray());
@@ -159,7 +159,12 @@ class CreateSubscriptions implements ObserverInterface
 
         $model = $this->subscriptionToProductRepository->save($model);
 
-        $this->eventManager->dispatch('mollie_subscription_created', ['subscription' => $model]);
+        $this->eventManager->dispatch('mollie_subscription_created', [
+            'model' => $model,
+            'order' => $order,
+            'subscription' => $subscription,
+            'dto' => $subscriptionOptions,
+        ]);
 
         $this->sendAdminNotificationEmail->execute($model);
         $this->sendCustomerNotificationEmail->execute($model);

--- a/Service/Mollie/SubscriptionOptions.php
+++ b/Service/Mollie/SubscriptionOptions.php
@@ -6,6 +6,7 @@
 
 namespace Mollie\Subscriptions\Service\Mollie;
 
+use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
@@ -62,18 +63,25 @@ class SubscriptionOptions
      */
     private $getShippingCostForOrderItem;
 
+    /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
     public function __construct(
         General $mollieHelper,
         UrlInterface $urlBuilder,
         ParseSubscriptionOptions $parseSubscriptionOptions,
         GetShippingCostForOrderItem $getShippingCostForOrderItem,
-        StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        ManagerInterface $eventManager
     ) {
         $this->mollieHelper = $mollieHelper;
         $this->urlBuilder = $urlBuilder;
         $this->parseSubscriptionOptions = $parseSubscriptionOptions;
         $this->getShippingCostForOrderItem = $getShippingCostForOrderItem;
         $this->storeManager = $storeManager;
+        $this->eventManager = $eventManager;
     }
 
     /**
@@ -116,7 +124,7 @@ class SubscriptionOptions
             $this->options['amount']
         );
 
-        return new SubscriptionOption(
+        $subscriptionOption = new SubscriptionOption(
             $orderItem->getProductId(),
             $this->currentOption->getIdentifier(),
             $this->order->getStoreId(),
@@ -128,6 +136,14 @@ class SubscriptionOptions
             $this->options['startDate'],
             $this->options['times'] ?? null
         );
+
+        $subscriptionOption->setOrderItem($orderItem);
+
+        $this->eventManager->dispatch('mollie_subscription_option_init', [
+            'dto' => $subscriptionOption
+        ]);
+
+        return $subscriptionOption;
     }
 
     private function addAmount(): void


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
The subscriptions module currently offers only limited extension points for project-specific subscription flows and customizations.

This PR adds a few event dispatches and makes the `SubscriptionOption` DTO mutable by adding setters. This allows external modules to adjust subscription data before the subscription is created and to react to subscription creation and renewal events without overriding core logic.

Added extension points:
- `mollie_subscription_option_init`
- `mollie_subscription_created`
- `mollie_subscription_renewed`

The `mollie_subscription_created` event payload was also expanded so observers can access the saved model, the Magento order, the Mollie subscription response, and the DTO that was used to create it.

**Important**
 Currently the change does contain a BC in Mollie\Subscriptions\Observer\MollieProcessTransactionEnd\CreateSubscriptions::createSubscription. The event data for "mollie_subscription_created" with the key "subscription" has changed to the subscription provided from the API gateway instead of the SubscriptionToOption entity.