### PR TITLE
Release/1.19.0

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ jobs:
           - PHP_VERSION: php74-fpm
             MAGENTO_VERSION: 2.4.4
           - PHP_VERSION: php84-fpm
-            MAGENTO_VERSION: 2.4.8-p2
+            MAGENTO_VERSION: 2.4.9
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,3 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: prestashop/github-action-php-lint/8.4@v2.3.1
+
+  # Pinned to master SHA because 8.5 is not yet included in a tagged release. Switch to a tag once available.
+  php-85:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: prestashop/github-action-php-lint/8.5@08f47878fdedbcecb581a8c93f507c7d60b2c956

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,7 +11,7 @@ jobs:
         - PHP_VERSION: php74-fpm
           MAGENTO_VERSION: 2.4.4
         - PHP_VERSION: php84-fpm
-          MAGENTO_VERSION: 2.4.8
+          MAGENTO_VERSION: 2.4.9
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/setup-di-compile.yml
+++ b/.github/workflows/setup-di-compile.yml
@@ -11,7 +11,7 @@ jobs:
         - PHP_VERSION: php74-fpm
           MAGENTO_VERSION: 2.4.4
         - PHP_VERSION: php84-fpm
-          MAGENTO_VERSION: 2.4.8
+          MAGENTO_VERSION: 2.4.9
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Console/Command/Selftest.php
+++ b/Console/Command/Selftest.php
@@ -56,7 +56,7 @@ class Selftest extends Command
     /**
      *  {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $result = $this->selftestRepository->test();
         foreach ($result as $test) {

--- a/Service/Magento/SubscriptionAddProductToCart.php
+++ b/Service/Magento/SubscriptionAddProductToCart.php
@@ -14,6 +14,7 @@ use Magento\Framework\DataObject;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Tax\Model\Calculation as TaxCalculation;
+use Magento\Tax\Model\Config as TaxConfig;
 use Mollie\Api\Resources\Subscription;
 
 class SubscriptionAddProductToCart
@@ -26,13 +27,19 @@ class SubscriptionAddProductToCart
      * @var TaxCalculation
      */
     private $taxCalculation;
+    /**
+     * @var TaxConfig
+     */
+    private $taxConfig;
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
-        TaxCalculation $taxCalculation
+        TaxCalculation $taxCalculation,
+        TaxConfig $taxConfig
     ) {
         $this->productRepository = $productRepository;
         $this->taxCalculation = $taxCalculation;
+        $this->taxConfig = $taxConfig;
     }
 
     public function execute(CartInterface $cart, Subscription $subscription): ProductInterface
@@ -86,7 +93,7 @@ class SubscriptionAddProductToCart
         $priceIncl = $subscription->amount->value / $quantity;
         $newPrice = $priceIncl;
 
-        if ($taxRate !== 0.0) {
+        if ($taxRate !== 0.0 && !$this->taxConfig->priceIncludesTax($item->getStore())) {
             $newPrice = $priceIncl / (1 + ($taxRate / 100));
         }
 

--- a/Service/Mollie/SubscriptionOptions.php
+++ b/Service/Mollie/SubscriptionOptions.php
@@ -133,7 +133,7 @@ class SubscriptionOptions
     private function addAmount(): void
     {
         if ($this->currentOption->getPrice() !== null) {
-            $this->options['amount'] = $this->currentOption->getPrice();
+            $this->options['amount'] = $this->currentOption->getPrice() * $this->orderItem->getQtyOrdered();
             return;
         }
 

--- a/Test/Integration/Service/Email/SendNotificationEmailTest.php
+++ b/Test/Integration/Service/Email/SendNotificationEmailTest.php
@@ -9,10 +9,11 @@ use Mollie\Payment\Test\Integration\IntegrationTestCase;
 use Mollie\Subscriptions\Api\Data\SubscriptionToProductInterface;
 use Mollie\Subscriptions\Service\Email\SendNotificationEmail;
 use Mollie\Subscriptions\Service\Email\SubscriptionToProductEmailVariables;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SendNotificationEmailTest extends IntegrationTestCase
 {
-    public function sendNotificationEmailProvider(): array
+    public static function sendNotificationEmailProvider(): array
     {
         return [
             ['adminNotification', 'admin', 'New subscription'],
@@ -36,6 +37,7 @@ class SendNotificationEmailTest extends IntegrationTestCase
      * @magentoAppIsolation enabled
      * @return void
      */
+    #[DataProvider('sendNotificationEmailProvider')]
     public function testSendNotificationEmail(string $configSource, string $sendTo, string $expectedSubject): void
     {
         $customer = new \Mollie\Api\Resources\Customer(new MollieApiClient);
@@ -84,6 +86,7 @@ class SendNotificationEmailTest extends IntegrationTestCase
      * @magentoAppIsolation enabled
      * @return void
      */
+    #[DataProvider('sendNotificationEmailProvider')]
     public function testWhenDisabledNoEmailIsSent(string $configSource, string $sendTo, string $expectedSubject): void
     {
         /** @var SendNotificationEmail $instance */

--- a/Test/Integration/Service/Magento/SubscriptionAddProductToCartTest.php
+++ b/Test/Integration/Service/Magento/SubscriptionAddProductToCartTest.php
@@ -1,0 +1,137 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Subscriptions\Test\Integration\Service\Magento;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\AddressInterfaceFactory;
+use Magento\Quote\Model\Quote;
+use Mollie\Api\Resources\Subscription;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+use Mollie\Subscriptions\Service\Magento\SubscriptionAddProductToCart;
+use stdClass;
+
+class SubscriptionAddProductToCartTest extends IntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $version = $this->objectManager->get(ProductMetadataInterface::class)->getVersion();
+        if (version_compare($version, '2.4.0', '<')) {
+            $this->markTestSkipped('TaxConfig caching behaviour on Magento < 2.4.0 interferes with these tests');
+        }
+    }
+
+    /**
+     * @see https://github.com/mollie/magento2-subscriptions/issues/104
+     *
+     * @magentoDataFixture Magento/Customer/_files/customer_with_addresses.php
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoDataFixture Magento/Tax/_files/tax_rule_region_1_al.php
+     * @magentoConfigFixture default_store tax/calculation/price_includes_tax 1
+     */
+    public function testSetsGrossPriceAsCustomPriceInTaxInclusiveStore(): void
+    {
+        $cart = $this->buildCartWithAlabamaBillingAddress();
+
+        $subscription = $this->objectManager->get(Subscription::class);
+        $subscription->amount = new stdClass();
+        $subscription->amount->value = 10.75;
+        $subscription->amount->currency = 'EUR';
+        $subscription->metadata = new stdClass();
+        $subscription->metadata->quantity = '1';
+        $subscription->metadata->sku = 'simple';
+
+        $instance = $this->objectManager->create(SubscriptionAddProductToCart::class);
+        $instance->execute($cart, $subscription);
+
+        $items = array_values($cart->getAllItems());
+        $item = $items[0];
+
+        // In a tax-inclusive store the subscription amount (10.75) is already the gross price.
+        // Setting original_custom_price to the net (10.75 / 1.075 = 10.00) causes Magento to
+        // treat it as inclusive and strip tax again, recording 10.00 instead of 10.75.
+        $this->assertEqualsWithDelta(
+            $subscription->amount->value,
+            (float)$item->getOriginalCustomPrice(),
+            0.01,
+            'In a tax-inclusive store, original_custom_price must be the gross subscription amount'
+        );
+    }
+
+    /**
+     * @magentoDataFixture Magento/Customer/_files/customer_with_addresses.php
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoDataFixture Magento/Tax/_files/tax_rule_region_1_al.php
+     * @magentoConfigFixture default_store tax/calculation/price_includes_tax 0
+     */
+    public function testSetsNetPriceAsCustomPriceInTaxExclusiveStore(): void
+    {
+        $cart = $this->buildCartWithAlabamaBillingAddress();
+
+        $subscription = $this->objectManager->get(Subscription::class);
+        $subscription->amount = new stdClass();
+        $subscription->amount->value = 10.75;
+        $subscription->amount->currency = 'EUR';
+        $subscription->metadata = new stdClass();
+        $subscription->metadata->quantity = '1';
+        $subscription->metadata->sku = 'simple';
+
+        $instance = $this->objectManager->create(SubscriptionAddProductToCart::class);
+        $instance->execute($cart, $subscription);
+
+        $items = array_values($cart->getAllItems());
+        $item = $items[0];
+
+        // In a tax-exclusive store the gross Mollie amount must be divided to get the net
+        // price, which Magento then uses as the base for adding tax.
+        $expectedNet = $subscription->amount->value / 1.075;
+
+        $this->assertEqualsWithDelta(
+            $expectedNet,
+            (float)$item->getOriginalCustomPrice(),
+            0.01,
+            'In a tax-exclusive store, original_custom_price must be the net price (gross / (1 + rate))'
+        );
+    }
+
+    private function buildCartWithAlabamaBillingAddress(): Quote
+    {
+        $customerRepository = $this->objectManager->get(CustomerRepositoryInterface::class);
+        $customer = $customerRepository->get('customer_with_addresses@test.com');
+
+        $cartManagement = $this->objectManager->get(CartManagementInterface::class);
+        $cartRepository = $this->objectManager->get(CartRepositoryInterface::class);
+
+        $cartId = $cartManagement->createEmptyCartForCustomer($customer->getId());
+        /** @var Quote $cart */
+        $cart = $cartRepository->get($cartId);
+
+        $address = $customer->getAddresses()[0];
+
+        $addressFactory = $this->objectManager->get(AddressInterfaceFactory::class);
+        $quoteAddress = $addressFactory->create();
+        $quoteAddress->setFirstname($address->getFirstname());
+        $quoteAddress->setLastname($address->getLastname());
+        $quoteAddress->setStreet($address->getStreet());
+        $quoteAddress->setCity($address->getCity());
+        $quoteAddress->setRegionId($address->getRegionId());
+        $quoteAddress->setCountryId($address->getCountryId());
+        $quoteAddress->setPostcode($address->getPostcode());
+        $quoteAddress->setTelephone($address->getTelephone());
+
+        $cart->setBillingAddress($quoteAddress);
+        $cart->setShippingAddress($quoteAddress);
+
+        return $cart;
+    }
+}

--- a/Test/Integration/Service/Mollie/SubscriptionOptionsTest.php
+++ b/Test/Integration/Service/Mollie/SubscriptionOptionsTest.php
@@ -252,6 +252,36 @@ class SubscriptionOptionsTest extends IntegrationTestCase
     /**
      * @magentoDataFixture Magento/Sales/_files/order.php
      */
+    public function testMultipliesCustomPriceByQuantity(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $items = $order->getItems();
+
+        /** @var OrderItemInterface $orderItem */
+        $orderItem = array_shift($items);
+        $orderItem->setQtyOrdered(3);
+
+        $this->setOptionIdOnOrderItem($orderItem, 'custom-price');
+        $this->setTheSubscriptionOnTheProduct(
+            $orderItem->getProduct(),
+            '{"identifier":"custom-price","title":"Custom price subscription","interval_amount":"1","interval_type":"weeks","repetition_type":"infinite","price":3.00}'
+        );
+
+        /** @var SubscriptionOptions $instance */
+        $instance = $this->objectManager->create(SubscriptionOptions::class);
+        $result = $instance->forOrder($order);
+
+        $this->assertCount(1, $result);
+        $subscription = $result[0];
+        $this->assertArrayHasKey('amount', $subscription->toArray());
+        $this->assertArrayHasKey('value', $subscription->toArray()['amount']);
+        // 3.00 per unit * 3 qty = 9.00, + 5.00 shipping
+        $this->assertEquals('14.00', $subscription->toArray()['amount']['value']);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
     public function testAddsTheWebhookUrl()
     {
         $order = $this->loadOrder('100000001');

--- a/Test/Integration/Service/Mollie/SubscriptionOptionsTest.php
+++ b/Test/Integration/Service/Mollie/SubscriptionOptionsTest.php
@@ -13,6 +13,7 @@ use Mollie\Payment\Test\Integration\IntegrationTestCase;
 use Mollie\Subscriptions\Config\Source\IntervalType;
 use Mollie\Subscriptions\DTO\SubscriptionOption;
 use Mollie\Subscriptions\Service\Mollie\SubscriptionOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SubscriptionOptionsTest extends IntegrationTestCase
 {
@@ -67,6 +68,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
      * @dataProvider includesTheCorrectIntervalProvider
      * @magentoDataFixture Magento/Sales/_files/order.php
      */
+    #[DataProvider('includesTheCorrectIntervalProvider')]
     public function testIncludesTheCorrectInterval($input, $expected)
     {
         $order = $this->loadOrder('100000001');
@@ -101,6 +103,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
      * @dataProvider addsADescriptionProvider
      * @magentoDataFixture Magento/Sales/_files/order.php
      */
+    #[DataProvider('addsADescriptionProvider')]
     public function testAddsADescription($input, $expected)
     {
         $order = $this->loadOrder('100000001');
@@ -303,6 +306,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
      * @param $input
      * @param $expected
      */
+    #[DataProvider('addsTheStartDate')]
     public function testAddsTheStartDate($input, $expected)
     {
         $order = $this->loadOrder('100000001');
@@ -340,6 +344,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
      * @param $input
      * @param $expected
      */
+    #[DataProvider('addsTheStartDate')]
     public function testAddsTheDelayedStartDate($input, $expected)
     {
         $order = $this->loadOrder('100000001');
@@ -458,7 +463,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
         $this->assertArrayNotHasKey('shippingAddressId', $subscription->toArray()['metadata']);
     }
 
-    public function includesTheCorrectIntervalProvider(): array
+    public static function includesTheCorrectIntervalProvider(): array
     {
         return [
             'day' => [['amount' => 7, 'type' => IntervalType::DAYS], '7 days'],
@@ -471,7 +476,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
         ];
     }
 
-    public function addsADescriptionProvider(): array
+    public static function addsADescriptionProvider(): array
     {
         return [
             'single day' => [['amount' => 1, 'type' => IntervalType::DAYS], 'Every day'],
@@ -485,7 +490,7 @@ class SubscriptionOptionsTest extends IntegrationTestCase
         ];
     }
 
-    public function addsTheStartDate(): array
+    public static function addsTheStartDate(): array
     {
         $now = new \DateTimeImmutable('now');
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mollie/magento2-subscriptions",
     "description": "Mollie subscriptions extension for Magento 2",
     "type": "magento2-module",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,7 +8,7 @@
     <default>
         <mollie_subscriptions>
             <general>
-                <version>v1.18.0</version>
+                <version>v1.19.0</version>
                 <enable>0</enable>
                 <debug>1</debug>
                 <update_subscription_when_price_changes>0</update_subscription_when_price_changes>


### PR DESCRIPTION
Feature: Magento 2.4.9 support
Bugfix: Use custom price as per-unit price #105
Bugfix: Subscription renewal order price in tax-inclusive stores #104